### PR TITLE
Increase head-lines value when get article info

### DIFF
--- a/hexo.el
+++ b/hexo.el
@@ -382,7 +382,7 @@ FILTER is a function with one arg."
   (date . date)
   (tags . (tags ...))
   (categories . (categories ...)))"
-  (let ((head-lines (hexo-get-file-head-lines file-path 6)))
+  (let ((head-lines (hexo-get-file-head-lines file-path 10)))
     (cl-remove-if
      #'null
      (mapcar (lambda (line)


### PR DESCRIPTION
From Hexo's doc, there are 8 front-matters supported in hexo.

Let's increase head-lines value to 10 when get-article-info.

doc link:
https://hexo.io/docs/front-matter.html

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>