### PR TITLE
add customable article suffixies support

### DIFF
--- a/hexo.el
+++ b/hexo.el
@@ -33,6 +33,11 @@
   "Faces used in `hexo-mode'"
   :group 'hexo :group 'faces)
 
+(defcustom article-suffixies '(".md" ".org")
+  "available article suffixies"
+  :group 'hexo
+  :type '(repeat string))
+
 (defvar-local hexo-root-dir nil
   "Root directory of a hexo-mode buffer")
 (put 'hexo-root-dir 'permanent-local t)
@@ -338,8 +343,9 @@ Also see: `hexo-generate-tabulated-list-entries'"
   (if (file-exists-p dir-path)
       (cl-remove-if (lambda (x) (or
                                  (not (file-exists-p x))
-                                 (and (not (string-suffix-p ".md" x))
-                                      (not (string-suffix-p ".org" x)))
+								 (not (member
+									   (concat "." (file-name-extension x))
+									   article-suffixies))
                                  (member (file-name-base x) '("." ".."))
                                  ;;(string-suffix-p "#" x) ;useless
                                  (string-suffix-p "~" x)))

--- a/hexo.el
+++ b/hexo.el
@@ -1164,7 +1164,7 @@ This is merely resonable for files in _posts/."
 (defun hexo-replace-hexo-command-to-path (command-string &optional repo-path)
   "Replace all 'hexo' in COMMAND-STRING to hexo command's path"
   (hexo-ensure-hexo-executable-available
-   (replace-regexp-in-string "_HEXO" hexo-executable-path command-string)))
+   (replace-regexp-in-string "_HEXO" hexo-executable-path command-string t)))
 
 (defun hexo-server-run ()
   "Run a Hexo server process (posts only / posts + drafts)"


### PR DESCRIPTION
```
(use-package hexo  
  :config  
  (add-to-list 'article-suffixies ".markdown"))
```

use new custom variables like this
I think it's better than hard code suffixies